### PR TITLE
Add model_type as argument to dolo-matlab

### DIFF
--- a/bin/dolo-matlab
+++ b/bin/dolo-matlab
@@ -9,7 +9,7 @@ parser = argparse.ArgumentParser(description='Matlab compiler')
 parser.add_argument('-v','--version', action='version', version=__version__)
 parser.add_argument('-d','--diff',  action='store_const', const=True, default=False, help='compute symbolic derivatives')
 parser.add_argument('-r','--print_residuals', action='store_const', const=True, default=False, help='print residuals at the steady-state')
-#parser.add_argument('-t','--model_type', nargs=1, type=str,  default=None, help='type of model')
+parser.add_argument('-t','--model_type', nargs=1, type=str,  default=None, help='type of model')
 parser.add_argument('--recipes', nargs=1, type=str, default=None, help='file containing recipes')
 
 parser.add_argument('input', help='model file')
@@ -68,8 +68,13 @@ if args.diff:
 else:
     diff = False
 
+if args.model_type:
+    model_type = args.model_type[0]
+else:
+    model_type = None
+
 from dolo.compiler.compiler_matlab import CompilerMatlab
-comp = CompilerMatlab(model, recipes=recipes)
+comp = CompilerMatlab(model, recipes=recipes, model_type=model_type)
 
 txt = comp.process_output( diff=diff )
 

--- a/examples/global_models/rbc_fgh.yaml
+++ b/examples/global_models/rbc_fgh.yaml
@@ -1,4 +1,4 @@
-model_type: fgh
+model_type: fgh2
 
 declarations:
 


### PR DESCRIPTION
I would like model_type to be optional in RECS, hence this update.
