### PR TITLE
adding necessary functions to time_iteration docstring

### DIFF
--- a/dolo/algos/time_iteration.py
+++ b/dolo/algos/time_iteration.py
@@ -44,7 +44,8 @@ def time_iteration(model, dr0=None, with_complementarities=True,
     Parameters
     ----------
     model : Model
-        model to be solved
+        model to be solved.
+        Must have ``transition`` and ``arbitrage`` functions.
     verbose : boolean
         if True, display iterations
     dr0 : decision rule


### PR DESCRIPTION
Adding a mention of `transition` and `arbitrage` to parameter docs.

Is this kind of change welcome?